### PR TITLE
Make additional identifiers searchable

### DIFF
--- a/app/models/manifestation.rb
+++ b/app/models/manifestation.rb
@@ -182,6 +182,10 @@ class Manifestation < ActiveRecord::Base
         identifier_contents(:issn)
       end
     end
+    text :identifier do
+      other_identifiers = identifiers.joins(:identifier_type).merge(IdentifierType.where.not(name: [:isbn, :issn]))
+      other_identifiers.pluck(:body)
+    end
     string :sort_title
     string :doi, multiple: true do
       identifier_contents(:doi)


### PR DESCRIPTION
資料に登録された ISBN, ISSN 以外の識別子を検索可能にする修正案です